### PR TITLE
Defensively check for presence of links in parsed Atom / RSS. 

### DIFF
--- a/src/django_push/subscriber/views.py
+++ b/src/django_push/subscriber/views.py
@@ -62,10 +62,11 @@ def callback(request, pk):
                 return HttpResponse('')
 
         parsed = feedparser.parse(request.raw_post_data)
-        if parsed.feed.links:
+        links = getattr(parsed.feed, 'links', None)
+        if links:
             hub_url = subscription.hub
             topic_url = subscription.topic
-            for link in parsed.feed.links:
+            for link in links:
                 if link['rel'] == 'hub':
                     hub_url = link['href']
                 elif link['rel'] == 'self':
@@ -84,3 +85,5 @@ def callback(request, pk):
 
             updated.send(sender=subscription, notification=parsed)
             return HttpResponse('')
+
+        return HttpResponse()

--- a/src/django_push/tests/sub/tests.py
+++ b/src/django_push/tests/sub/tests.py
@@ -1,0 +1,57 @@
+import urllib2
+import feedparser
+from StringIO import StringIO
+
+from django.test import TestCase
+
+from django_push.subscriber.models import Subscription
+from django_push.subscriber.signals import updated
+
+
+def mock_open(request):
+    raise urllib2.HTTPError('request', 204, 'no-op', {}, StringIO(''))
+
+urllib2.Request = lambda x, y, z: 'request'
+urllib2.urlopen = mock_open
+
+
+class SubTest(TestCase):
+
+    def signal_handler(self, notification, **kwargs):
+        self.signals.append(notification)
+
+    def setUp(self):
+        self.subscription = Subscription(
+            hub='http://testhub.example.com', topic='http://example.com/foo',
+            verified=True, verify_token='blah')
+        self.subscription.save()
+        self.signals = []
+        updated.connect(self.signal_handler)
+
+    def test_callback_invalid_feed_data(self):
+        """Ignore posts that contain invalid feed data in the raw post data."""
+        response = self.client.post(
+            '/pubsub/%d/' % (self.subscription.id,),
+            'foobar', content_type='application/atom+xml')
+        self.assertEquals(response.status_code, 200)
+
+    def test_callback_valid_feed_data(self):
+        feed_data = """<?xml version='1.0'?>
+        <feed xmlns='http://www.w3.org/2005/Atom' xml:lang='en-US'>
+            <link type='text/html' rel='alternate' href='http://example.com/'/>
+            <link type='application/atom+xml' rel='self'
+                href='http://example.com/feed/'/>
+            <entry>
+
+            </entry>
+        </feed>
+        """
+        parsed = feedparser.parse(feed_data)
+        response = self.client.post(
+            '/pubsub/%d/' % (self.subscription.id,),
+            feed_data, content_type='application/atom+xml')
+
+        # verify that we get a 200 and parsed as xml sent as a signal
+        self.assertEquals(response.status_code, 200)
+        last_signal = self.signals.pop()
+        self.assertTrue(parsed == last_signal)


### PR DESCRIPTION
Hey Bruno, not sure if you're interested in this patch, but I thought it'd be a good idea to check for the presence of 'links' attributes in the object returned from feedparser in the callback view code. Not doing this is sending a lot of Django error email to my mailbox :) 

Tests included, lemme know if you have any questions. 
